### PR TITLE
Update: Bump runtime to 48

### DIFF
--- a/io.github.halfmexican.Mingle.json
+++ b/io.github.halfmexican.Mingle.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.halfmexican.Mingle",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "47",
+    "runtime-version" : "48",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.vala"
@@ -35,7 +35,7 @@
             {
               "type": "git",
               "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-              "tag": "v0.12.0"
+              "tag": "v0.18.0"
             }
           ]
         },


### PR DESCRIPTION
Thank you for creating this app!

This PR rebuilds it against the GNOME 48 runtime and also updates blueprint.
I did not notice any drawbacks in my use.